### PR TITLE
0.9.1.3810 Map field updates

### DIFF
--- a/definitions/Map.dbd
+++ b/definitions/Map.dbd
@@ -239,7 +239,7 @@ MaxLevel<32>
 Unk0<32>
 Unk1<32>
 Unk2<32>
-Unk3<32>
+int<AreaTable::ID> AreaTableID
 MapDescription0_lang
 MapDescription1_lang
 Unk4<32>


### PR DESCRIPTION
- Renamed field unk3 to AreaTableID for build 0.9.1.3810
The field was confirmed by data comparison between 1.13.0.28211 and 0.9.1.3810 values.